### PR TITLE
implement biz logic for revenue by date

### DIFF
--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -2,11 +2,15 @@ class Api::V1::Merchants::RevenueController < ApiBaseController
 
   def index
     merchant = Merchant.find(params[:id])
-    render json: merchant.revenue_of_merchant
+    if merchant_params.keys == [:id, :date]
+      render json: merchant.revenue_by_date(merchant_params[:date])
+    else
+      render json: merchant.revenue_of_merchant
+    end
   end
 
   private
     def merchant_params
-      params.permit(:id)
+      params.permit(:id, :date)
     end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -27,4 +27,10 @@ class Merchant < ApplicationRecord
             .where(transactions: {result: "success"})
             .sum("invoice_items.unit_price * invoice_items.quantity")
   end
+
+  def revenue_by_date(date)
+    invoices.where(created_at: date)
+            .joins(:invoice_items)
+            .sum("invoice_items.unit_price * invoice_items.quantity")
+  end
 end

--- a/spec/controllers/api/v1/merchants/revenue_controller_spec.rb
+++ b/spec/controllers/api/v1/merchants/revenue_controller_spec.rb
@@ -17,4 +17,23 @@ RSpec.describe Api::V1::Merchants::RevenueController do
         expect(search).to eq 32
       end
     end
+
+    describe "GET index" do
+      fixtures :merchants
+      fixtures :transactions
+      fixtures :invoices
+      fixtures :invoice_items
+        it "can get total revenue for a single merchant by date" do
+          merchant = merchants(:one)
+          date = "2012-05-27 14:53:59"
+          get :index, id: merchant.id, date: date
+
+          expect(response.status).to eq 200
+          search = merchant.revenue_by_date(date)
+
+          expect(search).to eq 42
+        end
+      end
+
+
 end

--- a/spec/fixtures/invoices.yml
+++ b/spec/fixtures/invoices.yml
@@ -2,23 +2,28 @@ one:
   status: shipped
   customer: one
   merchant: two
+  created_at: 2012-03-27 14:53:59
 
 second_shipped:
   status: shipped
   customer: one
   merchant: one
+  created_at: 2012-04-27 14:53:59
 
 two:
   status: pending
   customer: two
   merchant: one
+  created_at: 2012-05-27 14:53:59
 
 three:
   status: pending
   customer: one
   merchant: one
+  created_at: 2012-06-27 14:53:59
 
 four:
   status: pending
   customer: one
   merchant: one
+  created_at: 2012-07-27 14:53:59


### PR DESCRIPTION
add revenue_by_date method to return total revenue by date for a merchant model
method uses single query in merchant model
added created_at dates to invoices fixture
added conditional for date to api/v1/ merchants revenue_controller

all tests passing
53 tests, 0 failures
